### PR TITLE
Ensure Snowflake notebook main accepts only session

### DIFF
--- a/sql_parser/notebook_single.py
+++ b/sql_parser/notebook_single.py
@@ -622,6 +622,7 @@ class SnowflakeQueryParser:
         return {"joins": joins, "filters": filters, "canonical_sql": canonical_sql, "ctes": ctes}
 
 # ---------------- Notebook helper ----------------
+CATALOG_TABLE = "YOUR_DB.YOUR_SCHEMA.CATALOG_VIEW"
 QUERY_HISTORY_TABLE = "SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY"
 START_EXPR = "DATEADD('day', -7, CURRENT_TIMESTAMP())"
 END_EXPR = "CURRENT_TIMESTAMP()"
@@ -629,7 +630,7 @@ MAX_ROWS = 5000
 QUERY_TYPES = ("SELECT","CREATE_VIEW","CREATE OR REPLACE VIEW","INSERT","MERGE","UPDATE")
 
 def parse_query_history(session: Session,
-                        catalog_table: str,
+                        catalog_table: str = CATALOG_TABLE,
                         query_history_table: str = QUERY_HISTORY_TABLE,
                         start_expr: str = START_EXPR,
                         end_expr: str = END_EXPR,
@@ -668,24 +669,11 @@ def parse_query_history(session: Session,
     return session.create_dataframe(rows, schema=schema)
 
 
-def main(session: Session,
-         catalog_table: str,
-         query_history_table: str = QUERY_HISTORY_TABLE,
-         start_expr: str = START_EXPR,
-         end_expr: str = END_EXPR,
-         max_rows: int = MAX_ROWS,
-         query_types: Tuple[str, ...] = QUERY_TYPES):
+def main(session: Session):
     """Snowflake stored procedure entry point.
 
-    This wrapper allows the parser to be invoked directly in Snowflake by
-    returning the same DataFrame produced by ``parse_query_history``.
+    Snowflake Python notebooks require ``main`` to accept only a ``Session``
+    argument. Additional configuration for the parser can be adjusted by
+    editing the module level constants above.
     """
-    return parse_query_history(
-        session,
-        catalog_table,
-        query_history_table=query_history_table,
-        start_expr=start_expr,
-        end_expr=end_expr,
-        max_rows=max_rows,
-        query_types=query_types,
-    )
+    return parse_query_history(session)


### PR DESCRIPTION
## Summary
- Configure Snowflake notebook helper to use module-level defaults, including a placeholder `CATALOG_TABLE`
- Update `parse_query_history` and `main` so the notebook entry point only accepts a `Session`

## Testing
- `pytest -q`
- `python -m py_compile sql_parser/notebook_single.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16563dce4832d8f5f68267daedcd0